### PR TITLE
Use stderr as input to stty to make it work in git hooks

### DIFF
--- a/frigg_runner/runner.py
+++ b/frigg_runner/runner.py
@@ -98,7 +98,7 @@ class Runner(object):
 
     def get_console_with(self):
         try:
-            rows, columns = os.popen('stty size', 'r').read().split()
+            rows, columns = os.popen('stty size <&2', 'r').read().split()
             return int(columns)
         except:
             return 79


### PR DESCRIPTION
This'll make it work in git hooks too, else it'll fail with the error `stty: stdin isn't a terminal`. Won't make any difference for `stty`'s output.
