### PR TITLE
Rewrite runner

### DIFF
--- a/.frigg.yml
+++ b/.frigg.yml
@@ -1,7 +1,8 @@
 tasks:
-  - tox
+  - tox -e py27
+  - tox -e py34
   - flake8
-  - isort -c -rc frigg_runner
+  - isort -c -rc frigg_runner tests
   - coverage combine && coverage xml && coverage report
 
 comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.idea/
+venv/

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Run the tasks:
     Options:
       -f, --failfast  Exit if one of the tasks returns other than statuscode 0.
       -v, --verbose   Print output from every task.
+      -p, --path      Working directory, the path where the friggfile lives.
       --help          Show this message and exit.
 
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,8 @@ Run the tasks:
     Usage: frigg [OPTIONS]
 
     Options:
-      -f, --failfast  Don't exit if one of the tasks returns other than statuscode 0.
+      -f, --failfast  Exit if one of the tasks returns other than statuscode 0.
+      -v, --verbose   Print output from every task.
       --help          Show this message and exit.
 
 

--- a/frigg_runner/cli.py
+++ b/frigg_runner/cli.py
@@ -7,7 +7,8 @@ from frigg_runner.runner import Runner
 
 @click.command()
 @click.option('-f', '--failfast', is_flag=True, default=False,
-              help='Don\'t exit if one of the tasks returns other than statuscode 0.')
+              help='Exit if one of the tasks returns other than statuscode 0.')
+@click.option('-v', '--verbose', is_flag=True, default=False, help='Print output from every task.')
 def main(**kwargs):
     Runner(**kwargs).run()
 

--- a/frigg_runner/cli.py
+++ b/frigg_runner/cli.py
@@ -9,6 +9,8 @@ from frigg_runner.runner import Runner
 @click.option('-f', '--failfast', is_flag=True, default=False,
               help='Exit if one of the tasks returns other than statuscode 0.')
 @click.option('-v', '--verbose', is_flag=True, default=False, help='Print output from every task.')
+@click.option('-p', '--path', default=None, help='Working directory, the path where the '
+                                                 'friggfile lives.')
 def main(**kwargs):
     Runner(**kwargs).run()
 

--- a/frigg_runner/runner.py
+++ b/frigg_runner/runner.py
@@ -78,7 +78,8 @@ class Runner(object):
         # List all tasks
         puts(colored.yellow('Tasks'))
         with indent(quote='#', indent=2):
-            [puts(colored.yellow(task)) for task in tasks]
+            for task in tasks:
+                puts(colored.yellow(task))
         newline()
 
         task_results = []

--- a/frigg_runner/runner.py
+++ b/frigg_runner/runner.py
@@ -14,7 +14,7 @@ from .utils import exit_build, newline, put_task_result, timeit
 
 class Runner(object):
 
-    def __init__(self, failfast, verbose):
+    def __init__(self, failfast, verbose, path=None):
         """
         Initialize the local build
 
@@ -23,11 +23,15 @@ class Runner(object):
         """
         self.fail_fast = failfast
         self.verbose = verbose
-        self.directory = os.getcwd()
+        self.directory = path or os.getcwd()
 
         puts(colored.blue('%s %s' % (__name__, __version__), bold=True))
         puts('Path: %s' % self.directory)
         newline()
+
+        if not os.path.exists(self.directory):
+            puts(colored.red('The given working directory does not exist'))
+            exit_build(False)
 
         try:
             self.config = projects.build_settings(self.directory)
@@ -60,7 +64,7 @@ class Runner(object):
         """
         try:
             if self.verbose:
-                puts(colored.yellow(command))
+                puts(colored.yellow(self.directory, command))
             result = invoke.run(command, hide=(bool(not self.verbose) or None))
             return result
         except Failure as failure:

--- a/frigg_runner/runner.py
+++ b/frigg_runner/runner.py
@@ -65,7 +65,8 @@ class Runner(object):
         try:
             if self.verbose:
                 puts(colored.yellow(self.directory, command))
-            result = invoke.run(command, hide=(bool(not self.verbose) or None))
+            result = invoke.run('cd %s && %s' % (self.directory, command),
+                                hide=(bool(not self.verbose) or None))
             return result
         except Failure as failure:
             return failure.result

--- a/frigg_runner/runner.py
+++ b/frigg_runner/runner.py
@@ -1,119 +1,143 @@
 # -*- coding: utf8 -*-
-
 import os
-import sys
 
-from frigg.projects import build_settings
-from invoke import run as cmd_run
+import frigg_coverage
+import invoke
+from clint.textui import colored, indent, progress, puts, puts_err
+from frigg import projects
 from invoke.exceptions import Failure
+from invoke.runner import Result
 
 from . import __name__, __version__
-
-HEADER = '\033[95m'
-OKBLUE = '\033[94m'
-OKGREEN = '\033[92m'
-FAIL = '\033[91m'
-ENDC = '\033[0m'
+from .utils import exit_build, newline, put_task_result, timeit
 
 
 class Runner(object):
 
-    def __init__(self, failfast):
+    def __init__(self, failfast, verbose):
+        """
+        Initialize the local build
+
+        :param failfast: Stop build then a task exit with a code other than 0
+        :param verbose: Print task output directly to stdout and stderr
+        """
         self.fail_fast = failfast
+        self.verbose = verbose
         self.directory = os.getcwd()
+
+        puts(colored.blue('%s %s' % (__name__, __version__), bold=True))
+        puts('Path: %s' % self.directory)
+        newline()
+
         try:
-            self.config = build_settings(self.directory)
+            self.config = projects.build_settings(self.directory)
         except RuntimeError:
-            print('No tasks found in %s' % self.directory)
+            puts(colored.red('No tasks found!'))
+            exit_build(True)
+
+    def coverage(self):
+        """
+        Check test coverage. Print coverage if coverage information exist in frigg configuration
+        """
+        try:
+            if self.config.get('coverage', False):
+                coverage = frigg_coverage.parse_coverage(
+                    os.path.join(self.directory, self.config['coverage']['path']),
+                    self.config['coverage']['parser']
+                )
+                puts(colored.blue('Coverage %s%s' % (round(coverage, ndigits=2), '%')))
+        except (KeyError, TypeError):
+            pass
+
+    @timeit
+    def run_task(self, command):
+        """
+        Run a task and return a task result
+        Print output based on the --verbose parameter
+
+        :param command: The command to execute
+        :return: (Result) Invoke task result
+        """
+        try:
+            if self.verbose:
+                puts(colored.yellow(command))
+            result = invoke.run(command, hide=(bool(not self.verbose) or None))
+            return result
+        except Failure as failure:
+            return failure.result
+        except SystemExit:
+            pass
+        return None
 
     def run(self):
-        self.print_welcome()
-
-        self.print_info_line('', color=OKBLUE)
-        self.print_info_line('Detected tasks:', color=OKBLUE)
+        """
+        Run all tasks
+        """
         tasks = self.config['tasks']
-        for task in tasks:
-            self.print_info_line('* %s' % task, color=OKBLUE)
-        self.print_hash_line(color=OKBLUE)
 
-        print('')
+        # List all tasks
+        puts(colored.yellow('Tasks'))
+        with indent(quote='#', indent=2):
+            [puts(colored.yellow(task)) for task in tasks]
+        newline()
 
-        status = {
-            'success': [],
-            'failure': []
-        }
+        task_results = []
+        with progress.Bar(label="Running tasks ", expected_size=len(tasks), width=60) as bar:
+            for task in tasks:
+                task_index = tasks.index(task)
+                task_time, task_result = self.run_task(task)
+                task_result.task = task
+                task_result.time = task_time
+                if isinstance(task_result, Result):
+                    task_results.append(task_result)
+                bar.show(task_index+1)
 
-        for task in tasks:
-            task_result = self.run_task(task)
-            if task_result:
-                status['success'].append(task)
-            else:
-                status['failure'].append(task)
+                # Fail fast
+                if task_result.failed and self.fail_fast:
+                    if not self.verbose:
+                        puts(colored.red(task_result.task))
+                        puts(task_result.stdout)
+                        puts_err(task_result.stderr)
+                    exit_build(False)
 
-            print('\n\n')
+        newline()
+        self.handle_results(task_results)
 
-        self.print_status(status)
+    def handle_results(self, task_results):
 
-    def run_task(self, command):
-        self.print_hash_line(color=HEADER)
-        self.print_info_line(command, color=HEADER)
-        self.print_hash_line(color=HEADER)
+        # Create a list of all failures
+        failures = []
+        for task_result in task_results:
+            if task_result.failed:
+                failures.append(task_result)
 
-        try:
-            print('')
-            cmd_run(command)
-        except (SystemExit, Failure):
+        # Print output from failed tasks, drop it if the runner is in verbose mode.
+        if len(failures) > 0 and not self.verbose:
+            puts(colored.red('Failures'))
+            for task_result in failures:
+                with indent(quote='#', indent=2):
+                    put_task_result(task_result, colored.red)
+                puts(task_result.stdout)
+                puts_err(task_result.stderr)
+            newline()
 
-            self.print_hash_line(color=FAIL)
-            self.print_info_line('%s exited with a statuscode other than 0' % command, color=FAIL)
-            self.print_hash_line(color=FAIL)
+        # Print the overall build result
+        puts(colored.blue('Result'))
+        with indent(quote='#', indent=2):
+            for task_result in task_results:
+                if task_result.failed:
+                    put_task_result(task_result, colored.red)
+                elif task_result.ok:
+                    put_task_result(task_result, colored.green)
 
-            if self.fail_fast:
-                sys.exit(1)
+        newline()
 
-            return False
+        # Print build time
+        puts(colored.blue('Total runtime: %ss' % round(sum(map(lambda task: task.time,
+                                                               task_results)), ndigits=2)))
 
-        return True
+        # Print coverage
+        self.coverage()
 
-    def print_welcome(self):
-        self.print_hash_line(color=OKBLUE)
-        self.print_info_line('%s %s' % (__name__, __version__), color=OKBLUE)
-
-    def print_hash_line(self, color=None):
-        prefix = ''
-        end = ''
-        if color:
-            prefix = color
-            end = ENDC
-        print(prefix + ''.join(['#' for x in range(self.get_console_with())]) + end)
-
-    def print_info_line(self, content, color=None):
-        prefix = ''
-        end = ''
-        if color:
-            prefix = color
-            end = ENDC
-        first = '# %s' % content
-        print(prefix + first.ljust((self.get_console_with()) - 1) + '#' + end)
-
-    def get_console_with(self):
-        try:
-            rows, columns = os.popen('stty size <&2', 'r').read().split()
-            return int(columns)
-        except:
-            return 79
-
-    def print_status(self, status):
-        if len(status['failure']) > 0:
-            self.print_hash_line(color=FAIL)
-            self.print_info_line('Build / Tests failure', color=FAIL)
-            self.print_info_line('The following tasks ended with a exitcode other than 0',
-                                 color=FAIL)
-            for task in status['failure']:
-                self.print_info_line('* %s' % task, color=FAIL)
-            self.print_hash_line(color=FAIL)
-
-        else:
-            self.print_hash_line(color=OKGREEN)
-            self.print_info_line('Build success!', color=OKGREEN)
-            self.print_hash_line(color=OKGREEN)
+        # Exit build with a message and a exit code
+        exit_build(bool(len(failures) == 0))

--- a/frigg_runner/utils.py
+++ b/frigg_runner/utils.py
@@ -1,0 +1,36 @@
+# -*- coding: utf8 -*-
+
+import sys
+import time
+
+from clint import textui
+
+
+def timeit(function):
+    def wrapper(*args, **kwargs):
+        t1 = time.time()
+        res = function(*args, **kwargs)
+        t2 = time.time()
+        return (t2 - t1), res
+    return wrapper
+
+
+def exit(code):
+    sys.exit(code)
+
+
+def exit_build(success):
+        if success:
+            textui.puts(textui.colored.green('Build success'))
+            exit(0)
+        else:
+            textui.puts(textui.colored.red('Build fail'))
+            exit(1)
+
+
+def newline():
+    textui.puts('\n', newline=False)
+
+
+def put_task_result(task_result, color):
+    textui.puts(color('%s (%s%s)' % (task_result.task, round(task_result.time, ndigits=2), 's')))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 wheel==0.24.0
 
 pytest
-pytest-cov
-pytest-sugar
 mock
+coverage
 
 click==3.3
 invoke
 pyaml
 frigg-common
+clint

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ requirements = [
 
 test_requirements = [
     'pytest',
-    'pytest-cov',
-    'pytest-sugar',
+    'coverage',
     'mock'
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,14 +20,19 @@ class CLITestCase(unittest.TestCase):
     def test_run(self, mock_run, mock_runner):
         self.runner.invoke(main)
         mock_run.assert_called_once()
-        mock_runner.assert_called_once_with(failfast=False, verbose=False)
+        mock_runner.assert_called_once_with(failfast=False, verbose=False, path=None)
 
     def test_run_with_failfast(self, mock_run, mock_runner):
         self.runner.invoke(main, ['--failfast'])
         mock_run.assert_called_once()
-        mock_runner.assert_called_once_with(failfast=True, verbose=False)
+        mock_runner.assert_called_once_with(failfast=True, verbose=False, path=None)
 
     def test_run_with_verbose(self, mock_run, mock_runner):
         self.runner.invoke(main, ['--verbose'])
         mock_run.assert_called_once()
-        mock_runner.assert_called_once_with(failfast=False, verbose=True)
+        mock_runner.assert_called_once_with(failfast=False, verbose=True, path=None)
+
+    def test_run_with_path(self, mock_run, mock_runner):
+        self.runner.invoke(main, ['--path', '/tmp'])
+        mock_run.assert_called_once()
+        mock_runner.assert_called_once_with(failfast=False, verbose=False, path='/tmp')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,9 @@ from frigg_runner.cli import main
 @mock.patch('frigg_runner.runner.Runner.__init__')
 @mock.patch('frigg_runner.runner.Runner.run')
 class CLITestCase(unittest.TestCase):
+    """
+    This class tests the cli module.
+    """
 
     def setUp(self):
         self.runner = CliRunner()
@@ -17,9 +20,14 @@ class CLITestCase(unittest.TestCase):
     def test_run(self, mock_run, mock_runner):
         self.runner.invoke(main)
         mock_run.assert_called_once()
-        mock_runner.assert_called_once_with(failfast=False)
+        mock_runner.assert_called_once_with(failfast=False, verbose=False)
 
     def test_run_with_failfast(self, mock_run, mock_runner):
         self.runner.invoke(main, ['--failfast'])
         mock_run.assert_called_once()
-        mock_runner.assert_called_once_with(failfast=True)
+        mock_runner.assert_called_once_with(failfast=True, verbose=False)
+
+    def test_run_with_verbose(self, mock_run, mock_runner):
+        self.runner.invoke(main, ['--verbose'])
+        mock_run.assert_called_once()
+        mock_runner.assert_called_once_with(failfast=False, verbose=True)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -76,9 +76,9 @@ class RunnerTestCase(unittest.TestCase):
         """
         Test function for running commands
         """
-        runner = Runner(False, True)
+        runner = Runner(False, True, '/tmp')
         runner.run_task('echo "Hello"')
-        mock_run.assert_called_once_with('echo "Hello"', hide=None)
+        mock_run.assert_called_once_with('cd %s && echo "Hello"' % runner.directory, hide=None)
 
     @mock.patch('frigg.projects.build_settings')
     @mock.patch('invoke.run', side_effect=Failure('Custom result'))
@@ -87,9 +87,9 @@ class RunnerTestCase(unittest.TestCase):
         Test function for command exec when the invoke return a Failure object
         """
 
-        runner = Runner(False, False)
+        runner = Runner(False, False, '/tmp')
         function_time, result = runner.run_task('echo "Hello"')
-        mock_run.assert_called_once_with('echo "Hello"', hide=True)
+        mock_run.assert_called_once_with('cd %s && echo "Hello"' % runner.directory, hide=True)
         self.assertEqual(result, 'Custom result')
         self.assertIsNotNone(function_time)
 
@@ -99,9 +99,9 @@ class RunnerTestCase(unittest.TestCase):
         """
         Test function for command exec when invoke exits
         """
-        runner = Runner(False, False)
+        runner = Runner(False, False, '/tmp')
         function_time, result = runner.run_task('echo "Hello"')
-        mock_run.assert_called_once_with('echo "Hello"', hide=True)
+        mock_run.assert_called_once_with('cd %s && echo "Hello"' % runner.directory, hide=True)
         self.assertIsNone(result)
 
     @mock.patch('frigg.projects.build_settings')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,1 +1,204 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
+import os
+import sys
+import unittest
+
+import invoke
+import mock
+from clint.textui import colored
+from frigg import projects
+from invoke.exceptions import Failure
+from invoke.runner import Result
+
+from frigg_runner.runner import Runner
+
+
+class RunnerTestCase(unittest.TestCase):
+
+    @mock.patch('frigg.projects.build_settings')
+    def test_runner_init(self, mock_run):
+        """
+        Test init of the runner class
+        """
+        runner = Runner(True, True)
+
+        self.assertTrue(runner.fail_fast)
+        self.assertTrue(runner.verbose)
+        self.assertEqual(runner.directory, os.getcwd())
+
+        projects.build_settings.assert_called_once_with(runner.directory)
+
+    def test_no_tasks(self):
+        """
+        No tasks, system exit.
+        """
+        def raise_runtime_error(*args, **kwargs):
+            raise RuntimeError
+
+        projects.build_settings = mock.Mock(side_effect=raise_runtime_error)
+
+        self.assertRaises(SystemExit, Runner, False, False)
+
+    @mock.patch('frigg_coverage.parse_coverage', side_effect=lambda *args, **kwargs: 10)
+    @mock.patch('clint.textui.colored.blue')
+    def test_coverage_success(self, mock_run, mock_run1):
+        """
+        Test coverage result print
+        """
+        runner = Runner(False, False)
+
+        runner.coverage()
+        colored.blue.assert_called_with('Coverage %s%s' % (round(10, ndigits=2), '%'))
+
+    def test_coverage_no_config(self):
+        """
+        Make sure noe exception raises when the coverage config not exist
+        """
+        runner = Runner(False, False)
+        del(runner.config['coverage'])
+        runner.coverage()
+
+    def test_coverage_invalid_config(self):
+        """
+        Test coverage function with invalid config
+        """
+        runner = Runner(False, False)
+        runner.config['coverage'] = True
+        runner.coverage()
+        runner.config['coverage'] = {}
+        runner.coverage()
+
+    @mock.patch('invoke.run')
+    @mock.patch('frigg.projects.build_settings')
+    def test_run_command(self, mock_run, mock_run1):
+        """
+        Test function for running commands
+        """
+        runner = Runner(False, True)
+        runner.run_task('echo "Hello"')
+        invoke.run.assert_called_once_with('echo "Hello"', hide=None)
+
+    @mock.patch('frigg.projects.build_settings')
+    def test_run_command_failure(self, mock_run):
+        """
+        Test function for command exec when the invoke return a Failure object
+        """
+        def raise_failure(*args, **kwargs):
+            raise Failure('Custom result')
+        invoke.run = mock.Mock(side_effect=raise_failure)
+
+        runner = Runner(False, False)
+        function_time, result = runner.run_task('echo "Hello"')
+        invoke.run.assert_called_once_with('echo "Hello"', hide=True)
+        self.assertEqual(result, 'Custom result')
+        self.assertIsNotNone(function_time)
+
+    @mock.patch('frigg.projects.build_settings')
+    def test_run_command_exit(self, mock_run):
+        """
+        Test function for command exec when invoke exits
+        """
+        def raise_failure(*args, **kwargs):
+            sys.exit(1)
+        invoke.run = mock.Mock(side_effect=raise_failure)
+
+        runner = Runner(False, False)
+        function_time, result = runner.run_task('echo "Hello"')
+        invoke.run.assert_called_once_with('echo "Hello"', hide=True)
+        self.assertIsNone(result)
+
+    @mock.patch('frigg.projects.build_settings')
+    def test_handle_result(self, mock_run):
+        """
+        Test sysexit when the build is done.
+        """
+        runner = Runner(False, False)
+
+        res1 = Result('', '', True, None)
+        res1.task = 'tox'
+        res1.time = 1
+        res2 = Result('', '', False, None)
+        res2.task = 'flake8'
+        res2.time = 2
+
+        try:
+            runner.handle_results([
+                res1, res2
+            ])
+        except SystemExit as sys_exit:
+            self.assertEqual(sys_exit.code, 1)
+
+        try:
+            runner.handle_results([
+                res2
+            ])
+        except SystemExit as sys_exit:
+            self.assertEqual(sys_exit.code, 0)
+
+        self.assertRaises(SystemExit, runner.handle_results, [res1, res2])
+
+    @mock.patch('frigg.projects.build_settings')
+    def test_run(self, mock_run):
+        """
+        Test the run function
+        """
+        runner = Runner(False, False)
+
+        runner.config = {
+            'tasks': [
+                'flake8',
+                'tox'
+            ]
+        }
+
+        def create_result(*args, **kwargs):
+            return 1, Result('', '', True, None)
+
+        runner.run_task = mock.Mock(side_effect=create_result)
+        runner.handle_results = mock.Mock()
+        runner.run()
+        runner.handle_results.assert_called_once()
+
+    @mock.patch('frigg.projects.build_settings')
+    def test_run_verbose(self, mock_run):
+        """
+        Test the run function
+        """
+        runner = Runner(False, True)
+
+        runner.config = {
+            'tasks': [
+                'flake8',
+                'tox'
+            ]
+        }
+
+        def create_result(*args, **kwargs):
+            return 1, Result('', '', True, None)
+
+        runner.run_task = mock.Mock(side_effect=create_result)
+        runner.handle_results = mock.Mock()
+        runner.run()
+        runner.handle_results.assert_called_once()
+
+    @mock.patch('frigg.projects.build_settings')
+    def test_run_fail_fast(self, mock_run):
+        """
+        Test the run function
+        """
+        runner = Runner(True, False)
+
+        runner.config = {
+            'tasks': [
+                'flake8',
+                'tox'
+            ]
+        }
+
+        def create_result(*args, **kwargs):
+            return 1, Result('', '', True, None)
+
+        runner.run_task = mock.Mock(side_effect=create_result)
+        runner.handle_results = mock.Mock()
+        self.assertRaises(SystemExit, runner.run)
+        runner.handle_results.assert_called_once()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -25,6 +25,15 @@ class RunnerTestCase(unittest.TestCase):
 
         mock_build_settings.assert_called_once_with(runner.directory)
 
+    @mock.patch('os.path.exists', side_effect=lambda *args, **kwargs: False)
+    @mock.patch('frigg.projects.build_settings')
+    def test_runner_init_cwd_not_found(self, mock_build_settings, mock_exists):
+        """
+        Test init of the runner class
+        """
+
+        self.assertRaises(SystemExit, Runner, True, True, '/tmp/doesnotexcist')
+
     @mock.patch('frigg.projects.build_settings', side_effect=RuntimeError)
     def test_no_tasks(self, mock_build_settings):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,64 @@
+# -*- coding: utf8 -*-
+import time
+import unittest
+
+import mock
+from clint import textui
+from invoke.runner import Result
+
+from frigg_runner.utils import exit, exit_build, newline, put_task_result, timeit
+
+
+class UtilsTestCase(unittest.TestCase):
+
+    @mock.patch('clint.textui.puts')
+    def test_newline(self, mock_run):
+        newline()
+        textui.puts.assert_called_once_with('\n', newline=False)
+
+    def test_exit(self):
+        self.assertRaises(SystemExit, exit, 0)
+
+        try:
+            exit(3)
+        except SystemExit as sys_exit:
+            self.assertEqual(sys_exit.code, 3)
+
+    def test_time_it(self):
+
+        @timeit
+        def sleep():
+            time.sleep(1)
+            return True
+
+        execute_time, result = sleep()
+
+        self.assertAlmostEqual(round(execute_time), 1)
+        self.assertTrue(result)
+
+    @mock.patch('clint.textui.puts')
+    def test_put_task_result(self, mock_run):
+        result = Result(None, None, None, None)
+        result.time = 2.9843
+        result.task = 'tox'
+
+        # Use str to mock the color wrapper.
+        color = str
+        put_task_result(result, color)
+        textui.puts.assert_called_once_with(color(
+            '%s (%s%s)' % (result.task, round(result.time, ndigits=2), 's')))
+
+    @mock.patch('clint.textui.puts')
+    def test_exit_build(self, mock_run):
+        self.assertRaises(SystemExit, exit_build, False)
+        textui.puts.assert_called_once()
+
+        try:
+            exit_build(True)
+        except SystemExit as sys_exit:
+            self.assertEqual(sys_exit.code, 0)
+
+        try:
+            exit_build(False)
+        except SystemExit as sys_exit:
+            self.assertEqual(sys_exit.code, 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@ import time
 import unittest
 
 import mock
-from clint import textui
 from invoke.runner import Result
 
 from frigg_runner.utils import exit, exit_build, newline, put_task_result, timeit
@@ -12,9 +11,9 @@ from frigg_runner.utils import exit, exit_build, newline, put_task_result, timei
 class UtilsTestCase(unittest.TestCase):
 
     @mock.patch('clint.textui.puts')
-    def test_newline(self, mock_run):
+    def test_newline(self, mock_puts):
         newline()
-        textui.puts.assert_called_once_with('\n', newline=False)
+        mock_puts.assert_called_once_with('\n', newline=False)
 
     def test_exit(self):
         self.assertRaises(SystemExit, exit, 0)
@@ -37,7 +36,7 @@ class UtilsTestCase(unittest.TestCase):
         self.assertTrue(result)
 
     @mock.patch('clint.textui.puts')
-    def test_put_task_result(self, mock_run):
+    def test_put_task_result(self, mock_puts):
         result = Result(None, None, None, None)
         result.time = 2.9843
         result.task = 'tox'
@@ -45,13 +44,13 @@ class UtilsTestCase(unittest.TestCase):
         # Use str to mock the color wrapper.
         color = str
         put_task_result(result, color)
-        textui.puts.assert_called_once_with(color(
+        mock_puts.assert_called_once_with(color(
             '%s (%s%s)' % (result.task, round(result.time, ndigits=2), 's')))
 
     @mock.patch('clint.textui.puts')
-    def test_exit_build(self, mock_run):
+    def test_exit_build(self, mock_puts):
         self.assertRaises(SystemExit, exit_build, False)
-        textui.puts.assert_called_once()
+        mock_puts.assert_called_once()
 
         try:
             exit_build(True)

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,4 @@ setenv =
 deps =
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run -p --source=frigg_runner -m py.test -v
+    coverage run -p --source=frigg_runner -m py.test -v tests


### PR DESCRIPTION
- Change design, use clint for commandline functions
- Only print tasks with error by default
- Print project coverage
- Display task execution time
- Write tests
- Fixes #9
- Fixes #8
- Fixes #4
