### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ MIT © frigg.io
 .. |Coverage status| image:: http://ci.frigg.io/badges/coverage/frigg/frigg-runner/
         :target: https://ci.frigg.io/frigg/frigg-runner/
 
-.. |pypi version| image:: https://pypip.in/version/frigg-runner/badge.svg?style=flat
+.. |pypi version| image:: https://img.shields.io/pypi/v/frigg-runner.svg?style=flat
     :target: https://pypi.python.org/pypi/frigg-runner/
 
 .. |requires| image:: https://requires.io/github/frigg/frigg-runner/requirements.svg?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20frigg-runner))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `frigg-runner`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.